### PR TITLE
gracefully shutdown within 30 seconds

### DIFF
--- a/app/Dockerfile.alpine
+++ b/app/Dockerfile.alpine
@@ -49,4 +49,4 @@ USER appuser
 ENV PORT=${PORT}
 EXPOSE $PORT
 
-ENTRYPOINT gunicorn --bind 0.0.0.0:${PORT} "app:create_app()"
+ENTRYPOINT gunicorn --bind 0.0.0.0:${PORT} --graceful-timeout 30 "app:create_app()"

--- a/deploy/helm-chart/flask-app/templates/deployment.yaml
+++ b/deploy/helm-chart/flask-app/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      terminationGracePeriodSeconds: 30
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Closes #32 

added terminationGracePeriodSeconds as 30s to deployment. 
added --graceful-timeout option as 30s to gunicorn. 
if k8s sends the SIGTERM it will wait 30s before sending SIGKILL.
gunicorn server handles the SIGTERM signal gracefully for its workers. if gunicorn get SIGTERM it will wait 30s for any worker to stop. if any worker can not stop within 30s gunicorn master will shutdown the server immediately.